### PR TITLE
Fix encoding of UTF-8 character cells

### DIFF
--- a/cmd-control.c
+++ b/cmd-control.c
@@ -164,7 +164,7 @@ control_history_print_line(struct cmd_ctx *ctx, struct grid_line *linedata)
 		cells[i].flags = (linedata->celldata[i].flags & flag_mask);
 		if (cells[i].flags & GRID_FLAG_UTF8)
 		    control_concat_utf8(linedata->utf8data + i,
-					cells[i].encoded + 1);
+					cells[i].encoded);
 		else
 		    sprintf(cells[i].encoded, "%02x",
 			    (linedata->celldata[i].data & 0xff));


### PR DESCRIPTION
Prior to this fix, UTF-8 character cells had odd length and the first
character of the encoded string was unset. Example: Instead of

```
[e280a6]
```

something like

```
5[e280a6]
```

was added to the encoded line.

This incorrectly encoded line in turn put iTerm2 into an infinite loop
in function "dataForHistoryLine". More precisely, in the loop

```
for (int i = 0; s[i]; ) { .. }
```

which has no termination clause, none of the conditionals that would
have incremented i matched.

This probably also fixes [iTerm2 issue 2302](http://code.google.com/p/iterm2/issues/detail?id=2302).
